### PR TITLE
Added explicit annotation during custom compile directive

### DIFF
--- a/app/scripts/directives/customvalidationtypes/customValidationTypes.js
+++ b/app/scripts/directives/customvalidationtypes/customValidationTypes.js
@@ -33,7 +33,7 @@
                 errorMessage: 'Cannot contain any spaces',
                 validateWhileEntering: true,
                 validator: function (errorMessageElement, val) {
-                    if (typeof(val) !== 'undefined' && val.trim() === '') {
+                    if (typeof (val) !== 'undefined' && val.trim() === '') {
                         return true;
                     }
                     return val !== '' && (/^[^\s]+$/).test(val);
@@ -190,20 +190,20 @@
         angular.forEach(myValidations.fetch(),
 
             function (customValidation) {
-                myValidations.compileDirective('input', function (customValidationUtil) {
+                myValidations.compileDirective('input', ['customValidationUtil', function (customValidationUtil) {
                     return {
                         require: '?ngModel',
                         restrict: 'E',
                         link: customValidationUtil.createValidationLink(customValidation)
                     };
-                });
-                myValidations.compileDirective('textarea', function (customValidationUtil) {
+                }]);
+                myValidations.compileDirective('textarea', ['customValidationUtil', function (customValidationUtil) {
                     return {
                         require: '?ngModel',
                         restrict: 'E',
                         link: customValidationUtil.createValidationLink(customValidation)
                     };
-                });
+                }]);
             });
     });
 


### PR DESCRIPTION
When using the ng-strict-di, it will complain that the function(customValidationUtil) is not using explicit annotation. By adding this two simple fix, to annotate this (most probably ng-annotate does not meant to generate the annotation for this function).

This is to resolve #75 